### PR TITLE
Fix limitation skills #1/2 - Tout débloqué

### DIFF
--- a/code/modules/mob/skills/skill.dm
+++ b/code/modules/mob/skills/skill.dm
@@ -131,7 +131,6 @@ GLOBAL_LIST_EMPTY(skills)
 						"Experienced"		= "You are an experienced pilot, and can safely take the helm of many types of craft. You could probably live in a spacecraft, and you're very well versed in essentially everything related to space-faring vessels. Not only can you fly a ship, but you can perform difficult maneuvers, and make most calculations related to piloting a spacecraft. You can maintain a ship. Skills of this level are typical for very experienced pilots. You have received formal piloting training.<br>- You can completely avoid meteors on normal speed while using tiny shuttlecrafts.",
 						"Master"		= "Not only are you an exceptional pilot, but you have mastered peripheral functions such as stellar navigation and bluespace jump plotting. You have experience performing complex maneuvers, managing squadrons of small craft, and operating in hostile environments.<br>- You can completely avoid meteors on normal speed using any shuttlecrafts.<br>- Less meteors will hit the ship while passing through meteor fields.")
 	difficulty = SKILL_AVERAGE
-	default_max = SKILL_ADEPT
 
 /decl/hierarchy/skill/general/hauling
 	ID = "hauling"

--- a/code/modules/mob/skills/skill.dm
+++ b/code/modules/mob/skills/skill.dm
@@ -13,7 +13,7 @@ GLOBAL_LIST_EMPTY(skills)
 							"Experienced"		= "Experienced Description",
 							"Master"		= "Professional Description")
 	var/difficulty = SKILL_AVERAGE         //Used to compute how expensive the skill is
-	var/default_max = SKILL_ADEPT          //Makes the skill capped at this value in selection unless overriden at job level.
+	var/default_max = SKILL_MAX          //Makes the skill capped at this value in selection unless overriden at job level.
 	var/prerequisites                      // A list of skill prerequisites, if needed.
 
 /decl/hierarchy/skill/proc/get_cost(var/level)
@@ -43,19 +43,16 @@ GLOBAL_LIST_EMPTY(skills)
 	name = "Organizational"
 	ID	 = "1"
 	difficulty = SKILL_EASY
-	default_max = SKILL_MAX
 
 /decl/hierarchy/skill/general
 	name = "General"
 	ID	 = "2"
 	difficulty = SKILL_EASY
-	default_max = SKILL_MAX
 
 /decl/hierarchy/skill/service
 	name = "Service"
 	ID	 = "service"
 	difficulty = SKILL_EASY
-	default_max = SKILL_MAX
 
 /decl/hierarchy/skill/security
 	name = "Security"


### PR DESCRIPTION
### Première potentielle solution à l'issue #7.
- **Tous les skills** sont dévérouillés pour **tout le monde**.

Simplissime, mais peut-être pas la meilleure solution.
Il est aussi possible de dévérouiller ces skills en fonction des jobs (cf PR #9).